### PR TITLE
remove useless rule 

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -7524,7 +7524,7 @@ m.search.naver.com##section._nshopping_trendview > div > div > div._product_root
 postshare.co.kr##body > div[class^="brand-"]
 postshare.co.kr##.addot-wrapper
 postshare.co.kr##div.warp > a[href*="//someblossom.co.kr/product/detail.html?"]
-copytoon248.com,copytoon249.com,copytoon250.com,copytoon251.com,copytoon252.com,copytoon253.com,copytoon254.com,copytoon255.com,copytoon256.com,copytoon257.com,copytoon258.com##a[href*="/bbs/bannerhit.php?"]
+copytoon*.com##a[href*="/bbs/bannerhit.php?"]
 sports.chosun.com##div[class^="ad"]
 mule.co.kr##.header-center.cf > .header-center-imgbox > a > img[src*="//cdn.mule.co.kr/data/original/"]
 mule.co.kr##div[class^="section-"][class$="-ad"]

--- a/filter.txt
+++ b/filter.txt
@@ -6037,7 +6037,6 @@ newsway.kr##div#google_banner
 newsway.kr##div[id^="NMN_BANNER_WIDGET_"]
 newsworker.co.kr##div#ad_scrollB
 newsworker.co.kr##div#floating_banner_body
-newtoki95.com##div#id_mbv
 newyorker.com##div.ad
 newyorker.com##div.full-bleed-ad
 nextdaily.co.kr##p.mgb20

--- a/filter.txt
+++ b/filter.txt
@@ -7427,9 +7427,6 @@ ytn.co.kr##div.ad_box
 ytn.co.kr##div.hns_mask_div
 ytn.co.kr##iframe[src^="/inc_banner/AdServerChange.php"]
 enuri.com,ytn.co.kr##.ad_powerlink
-zangsisi.net##body>center
-zangsisi.net##div#fixed-top
-zangsisi.net##div.fixed-top>center
 zbn.donga.com##div#iwm_fsa_wrap
 zbn.donga.com##div.realssp_dv
 zbn.donga.com##iframe[src^="/2015/banner/ad_real_"]

--- a/lightway/unstable_connection.txt
+++ b/lightway/unstable_connection.txt
@@ -5,7 +5,7 @@
 103.204.13.68##.product-banner
 103.204.13.68##div[class^="mobile-m ad720_"]
 ||wwwimageup.angle777899.com/other/atoona/
-copytoon248.com,copytoon249.com,copytoon250.com,copytoon251.com,copytoon252.com,copytoon253.com,copytoon254.com,copytoon255.com,copytoon256.com,copytoon257.com,copytoon258.com##a[href*="/bbs/bannerhit.php?"]
+copytoon*.com##a[href*="/bbs/bannerhit.php?"]
 ||torrentdia*.com/data/to_list
 torrentdia12.com##[href*=".com/bbs/bannerhit.php?"]
 torrentonly5.com##a[href^="https://www.torrentonly5.com/bbs/bannerhit.php?"]


### PR DESCRIPTION
1. zangsisi.net - https://namu.wiki/w/%EC%9E%A5%EC%8B%9C%EC%8B%9C

2. copytoon*.com - use wildcard, currently url is copytoon251.com

3. this rule is remove login box

![image](https://user-images.githubusercontent.com/34261355/158010585-b248efb8-293d-4488-bad8-73b98c58c2bf.png)
