### PR TITLE
Remove banner ad at bottom on namu.wiki

### DIFF
--- a/filters/extended_css.txt
+++ b/filters/extended_css.txt
@@ -30,3 +30,5 @@ ppomppu.co.kr#?#ul#new_bbs_best > li > a.title span[style="color:#1264b1;"]:upwa
 m.bobaedream.co.kr#?#div[style^="display:flex;"] > div[id^="div-gpt-ad-"]:upward(1)
 bobaedream.co.kr#?#tr.best > td a[href*="bobaedream.co.kr/event/event_list.php?"]:upward(2)
 orbi.kr#?#a[class="tag"][href^="/list/tag/"][-ext-contains="#제휴사공지"]:upward(li.notice)
+namu.wiki##article>p+div div[id]:has(div[id]:has(div[id]>ul>li,div>a[href*="/w/%EB%B6%84%EB%A5%98:"]))~div:has(img[src*="//w.namu.la/s/"])
+namu.wiki##article>p+div div[id]:has(div[id]:has(div[id]>ul>li,div>a[href*="/w/%EB%B6%84%EB%A5%98:"]))~div:has(img[src*="//w.namu.la/s/"],img[src^="data:image/png;base64,"])

--- a/filters/extended_css.txt
+++ b/filters/extended_css.txt
@@ -1,3 +1,4 @@
+namu.wiki##article>p+div div[id]:has(div[id]:has(div[id]>ul>li,div>a[href*="/w/%EB%B6%84%EB%A5%98:"]))~div:has(img[src*="//w.namu.la/s/"],img[src^="data:image/png;base64,"])
 m.dcinside.com#?#section.gall-lst-group > ul > li:has(> div.detail-top-lnk > a[href*="//addc.dcinside.com/"].lt > span:contains(AD))
 gall.dcinside.com#?#table.gall_list > tbody > tr:has(> td.gall_subject > b:contains(AD)):has(> td.gall_tit > a[href*="//addc.dcinside.com/"])
 mule.co.kr#?##section-main.cf > div[class^="section-"] > div[class^="section-"] > div:has( > a[href][alt][target="_blank"] > img[alt][src])
@@ -30,4 +31,3 @@ ppomppu.co.kr#?#ul#new_bbs_best > li > a.title span[style="color:#1264b1;"]:upwa
 m.bobaedream.co.kr#?#div[style^="display:flex;"] > div[id^="div-gpt-ad-"]:upward(1)
 bobaedream.co.kr#?#tr.best > td a[href*="bobaedream.co.kr/event/event_list.php?"]:upward(2)
 orbi.kr#?#a[class="tag"][href^="/list/tag/"][-ext-contains="#제휴사공지"]:upward(li.notice)
-namu.wiki##article>p+div div[id]:has(div[id]:has(div[id]>ul>li,div>a[href*="/w/%EB%B6%84%EB%A5%98:"]))~div:has(img[src*="//w.namu.la/s/"],img[src^="data:image/png;base64,"])

--- a/filters/extended_css.txt
+++ b/filters/extended_css.txt
@@ -30,5 +30,4 @@ ppomppu.co.kr#?#ul#new_bbs_best > li > a.title span[style="color:#1264b1;"]:upwa
 m.bobaedream.co.kr#?#div[style^="display:flex;"] > div[id^="div-gpt-ad-"]:upward(1)
 bobaedream.co.kr#?#tr.best > td a[href*="bobaedream.co.kr/event/event_list.php?"]:upward(2)
 orbi.kr#?#a[class="tag"][href^="/list/tag/"][-ext-contains="#제휴사공지"]:upward(li.notice)
-namu.wiki##article>p+div div[id]:has(div[id]:has(div[id]>ul>li,div>a[href*="/w/%EB%B6%84%EB%A5%98:"]))~div:has(img[src*="//w.namu.la/s/"])
 namu.wiki##article>p+div div[id]:has(div[id]:has(div[id]>ul>li,div>a[href*="/w/%EB%B6%84%EB%A5%98:"]))~div:has(img[src*="//w.namu.la/s/"],img[src^="data:image/png;base64,"])


### PR DESCRIPTION
Adds banner ad after the content area on namu.wiki.

Adding rule from:

- https://github.com/yous/YousList/pull/212#issuecomment-1065946899

Tested on ungoogled-chromium on macOS with AdGuard Web.

![image](https://user-images.githubusercontent.com/30369714/158048328-5801b352-5e7c-4a3a-ae96-ca6840b13df4.png)
