### PR TITLE
namu.wiki powerlink - Ad (changes a bit)

### DIFF
--- a/filters/extended_css_ELEMHIDE.txt
+++ b/filters/extended_css_ELEMHIDE.txt
@@ -1,4 +1,4 @@
-namu.wiki#?#article > p + div div[id]:has(div[id]:has(div[id] > ul > li, div > a[href*="/w/%EB%B6%84%EB%A5%98:"])) ~ div:has(img[src*="//w.namu.la/s/"], img[src^="data:image/png;base64,"])
+namu.wiki#?#article > p + div div[id]:has(div[id]:has(div > ul > li, div > a[href*="/w/%EB%B6%84%EB%A5%98:"])) ~ div:has(img[src*="//w.namu.la/s/"], img[src^="data:image/png;base64,"])
 m.dcinside.com#?#section.gall-lst-group > ul > li:has(> div.detail-top-lnk > a[href*="//addc.dcinside.com/"].lt > span:contains(AD))
 gall.dcinside.com#?#table.gall_list > tbody > tr:has(> td.gall_subject > b:contains(AD)):has(> td.gall_tit > a[href*="//addc.dcinside.com/"])
 mule.co.kr#?##section-main.cf > div[class^="section-"] > div[class^="section-"] > div:has( > a[href][alt][target="_blank"] > img[alt][src])


### PR DESCRIPTION
Simply, removing a `[id]` condition from `div` works well:

```css
#?#article > p + div div[id]:has(div[id]:has(div > ul > li, div > a[href*="/w/%EB%B6%84%EB%A5%98:"])) ~ div:has(img[src*="//w.namu.la/s/"], img[src^="data:image/png;base64,"])
```

Here's a proof:

![image](https://user-images.githubusercontent.com/30369714/158242962-bd361438-071b-40c8-9288-3b23119f05fa.png)

Old rule doesn't work:

![image](https://user-images.githubusercontent.com/30369714/158243144-18186581-346b-47be-b97a-7f7ffe0e1090.png)

Resolves:
- #236