### PR TITLE
namu.wiki - Ad (powerlink)

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR
-! Version: 2022.0315.09
+! Version: 2022.0316.1
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! License: https://github.com/List-KR/List-KR/blob/master/LICENSE

--- a/filters/contentblocker.txt
+++ b/filters/contentblocker.txt
@@ -18,4 +18,3 @@
 @@||videoads.kakao.com/adserver/api/v2/vmap$domain=tv.kakao.com|play-tv.kakao.com|entertain.daum.net
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=cpsp.kr
 @@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$domain=1412.rest
-namu.wiki##article > h1 + p ~ div[id][class]

--- a/filters/extended_css_ELEMHIDE.txt
+++ b/filters/extended_css_ELEMHIDE.txt
@@ -1,4 +1,4 @@
-namu.wiki#?#article > p + div div[id]:has(div[id]:has(div > ul > li, div > a[href*="/w/%EB%B6%84%EB%A5%98:"])) ~ div:has(img[src*="//w.namu.la/s/"], img[src^="data:image/png;base64,"])
+namu.wiki#?#article div:has(a[href*="/w/%EB%B6%84%EB%A5%98:"]) ~ div:has(td > img[src*="w.namu.la"], td > img[src^="data:image/png;base64,"])
 m.dcinside.com#?#section.gall-lst-group > ul > li:has(> div.detail-top-lnk > a[href*="//addc.dcinside.com/"].lt > span:contains(AD))
 gall.dcinside.com#?#table.gall_list > tbody > tr:has(> td.gall_subject > b:contains(AD)):has(> td.gall_tit > a[href*="//addc.dcinside.com/"])
 mule.co.kr#?##section-main.cf > div[class^="section-"] > div[class^="section-"] > div:has( > a[href][alt][target="_blank"] > img[alt][src])

--- a/filters/extended_css_ELEMHIDE.txt
+++ b/filters/extended_css_ELEMHIDE.txt
@@ -1,3 +1,4 @@
+namu.wiki#?#article > p + div div[id]:has(div[id]:has(div > ul > li, div > a[href*="/w/%EB%B6%84%EB%A5%98:"])) ~ div:has(img[src*="//w.namu.la/s/"], img[src^="data:image/png;base64,"])
 namu.wiki#?#article div:has(a[href*="/w/%EB%B6%84%EB%A5%98:"]) ~ div:has(td > img[src*="w.namu.la"], td > img[src^="data:image/png;base64,"])
 m.dcinside.com#?#section.gall-lst-group > ul > li:has(> div.detail-top-lnk > a[href*="//addc.dcinside.com/"].lt > span:contains(AD))
 gall.dcinside.com#?#table.gall_list > tbody > tr:has(> td.gall_subject > b:contains(AD)):has(> td.gall_tit > a[href*="//addc.dcinside.com/"])


### PR DESCRIPTION
Namuwiki updated their site structure again.

Note that this rule has high-sensitivity and maybe block the non-ad content when namu.wiki update their structure.

### Proofs

<img width="1312" alt="image" src="https://user-images.githubusercontent.com/30369714/158468475-09ac87c6-3755-4349-90de-1b6a09258b67.png">

<img width="979" alt="image" src="https://user-images.githubusercontent.com/30369714/158468582-2c5a66ce-a391-4fc9-a5b4-c829fbf93830.png">
