### PR TITLE
incorrect-blocking: fixup namu.wiki powerlink

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR
-! Version: 2022.322.13
+! Version: 2022.322.14
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! License: https://github.com/List-KR/List-KR/blob/master/LICENSE

--- a/filters/extended_css_ELEMHIDE.txt
+++ b/filters/extended_css_ELEMHIDE.txt
@@ -1,4 +1,4 @@
-namu.wiki#?#article div:has(a[href*="/w/%EB%B6%84%EB%A5%98:"]) ~ div:has(tr > td img[src^="//ww.namu.la"])
+namu.wiki#?#article div:has(a[href*="/w/%EB%B6%84%EB%A5%98:"]) ~ div:has(tr > td img[src^="//ww.namu.la"] + div[class] + div[class])
 gigglehd.com#?#div[style~="!important;"] > .nw_box > div:not(class):not(id) > table[cellspacing="0"][class]:not(:has(a[href*="//gigglehd.com/gg/"]))
 instiz.net#?#.responsive_main > div[style] > .grouping_title:has(> div[style][class] > div[style]:contains(광고))
 ajunews.com#?#.aside_item.banner:has(> h4[style~="font-size:13px;color:#999999;margin:0"]:contains(AD))


### PR DESCRIPTION
There are documents may blocked incorrectly due to the previous rule. Update is required.