### PR TITLE
[Needs manual check] ppss.kr - Ad (with various types)

### DIFF
--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin
-! Version: 2022.323.2
+! Version: 2022.323.3
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! License: https://github.com/List-KR/List-KR/blob/master/LICENSE

--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin
-! Version: 2022.323.3
+! Version: 2022.324.1
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! License: https://github.com/List-KR/List-KR/blob/master/LICENSE

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard
-! Version: 2022.323.11
+! Version: 2022.324.1
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! License: https://github.com/List-KR/List-KR/blob/master/LICENSE

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard
-! Version: 2022.323.10
+! Version: 2022.323.11
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! License: https://github.com/List-KR/List-KR/blob/master/LICENSE

--- a/filters-AG/general_extension.txt
+++ b/filters-AG/general_extension.txt
@@ -1,3 +1,5 @@
+ppss.kr#%#//scriptlet("set-constant", "Element.prototype.removeAttribute", "trueFunc")
+ppss.kr#%#//scriptlet("set-constant", "alert", "trueFunc")
 search.danawa.com#%#//scriptlet("set-constant", "getPowerLink", "undefined")
 search.11st.co.kr#%#//scriptlet("set-constant", "searchDataFactory.plusPrdList", "undefined")
 ygosu.com,ppss.kr#%#//scriptlet("set-constant", "setInterval", "trueFunc")

--- a/filters-share/extended_css_ELEMHIDE.txt
+++ b/filters-share/extended_css_ELEMHIDE.txt
@@ -1,9 +1,3 @@
-ppss.kr###custom_html-3
-ppss.kr###genesis-content > :not(div.home-top)
-ppss.kr###ppss_wing_banner_left
-ppss.kr##.ad-video
-ppss.kr##.brand-margin
-ppss.kr##div[onclick*="clickSdrcCheck"]
 namu.wiki#?#article div:has(> div.wiki-paragraph) ~ div:has(table > tbody > tr > td[class] > div > img[src*="w.namu.la/"])
 gigglehd.com#?#div[style~="!important;"] > .nw_box > div:not(class):not(id) > table[cellspacing="0"][class]:not(:has(a[href*="//gigglehd.com/gg/"]))
 instiz.net#?#.responsive_main > div[style] > .grouping_title:has(> div[style][class] > div[style]:contains(광고))

--- a/filters-share/extended_css_ELEMHIDE.txt
+++ b/filters-share/extended_css_ELEMHIDE.txt
@@ -1,5 +1,5 @@
 ppss.kr###custom_html-3
-ppss.kr###genesis-content > div,span:not(:has(header)):not([itemprop])
+ppss.kr###genesis-content > :not(div.home-top)
 ppss.kr###ppss_wing_banner_left
 ppss.kr##.ad-video
 ppss.kr##.brand-margin

--- a/filters-share/extended_css_ELEMHIDE.txt
+++ b/filters-share/extended_css_ELEMHIDE.txt
@@ -1,3 +1,9 @@
+ppss.kr###custom_html-3
+ppss.kr###genesis-content > div,span:not(:has(header)):not([itemprop])
+ppss.kr###ppss_wing_banner_left
+ppss.kr##.ad-video
+ppss.kr##.brand-margin
+ppss.kr##div[onclick*="clickSdrcCheck"]
 namu.wiki#?#article div:has(> div.wiki-paragraph) ~ div:has(table > tbody > tr > td[class] > div > img[src*="w.namu.la/"])
 gigglehd.com#?#div[style~="!important;"] > .nw_box > div:not(class):not(id) > table[cellspacing="0"][class]:not(:has(a[href*="//gigglehd.com/gg/"]))
 instiz.net#?#.responsive_main > div[style] > .grouping_title:has(> div[style][class] > div[style]:contains(광고))

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -1,3 +1,9 @@
+ppss.kr###custom_html-3
+ppss.kr###genesis-content > :not(div.home-top)
+ppss.kr###ppss_wing_banner_left
+ppss.kr##.ad-video
+ppss.kr##.brand-margin
+ppss.kr##div[onclick*="clickSdrcCheck"]
 m.ohmynews.com##main#article > .arc_list
 m.ohmynews.com##div[id^="mobitree"]
 m.ohmynews.com##iframe[src*="//ojsfile.ohmynews.com/AD_FILE/"]

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -1,5 +1,5 @@
 ppss.kr###custom_html-3
-ppss.kr###genesis-content > :not(div.home-top)
+ppss.kr###genesis-content > :not(.home-top, .post, .author-box, .pagination, .screen-reader-text)
 ppss.kr###ppss_wing_banner_left
 ppss.kr##.ad-video
 ppss.kr##.brand-margin

--- a/filters-uBO/general_extension.txt
+++ b/filters-uBO/general_extension.txt
@@ -1,3 +1,5 @@
+ppss.kr##+js(set, Element.prototype.removeAttribute, trueFunc)
+ppss.kr##+js(set, alert, trueFunc)
 search.danawa.com##+js(set, getPowerLink, undefined)
 search.11st.co.kr##+js(set, searchDataFactory.plusPrdList, undefined)
 ygosu.com,ppss.kr##+js(set, setInterval, trueFunc)


### PR DESCRIPTION
This PR hides various types of ADs and thanks to ㅍㅍㅅㅅ site owner, we can safely mute and ignore AdShield on the site without getting the headache to remove it.

This filter won't remove adshield (as I am investigating their script) but would like to block the parent node of the ad and mute adshield not to tell `adblock detected`.

Only, I concern is concentrated to some mobile users as they don't have ability to inject scriptlets.