### PR TITLE
feat: adshield with safer block

### DIFF
--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin. Do not add this filter into your DNS filter.
-! Version: 2022.519.5
+! Version: 2022.520.0
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin. Do not add this filter into your DNS filter.
-! Version: 2022.519.4
+! Version: 2022.519.5
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.519.4
+! Version: 2022.519.5
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.519.5
+! Version: 2022.520.0
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filters-AG/scriptlets.txt
+++ b/filters-AG/scriptlets.txt
@@ -1,8 +1,7 @@
 ! Topics API for advertisement
 #%#//scriptlet("set-constant", "document.browsingTopics", "undefined")
 ! Ad-Shield
-inven.co.kr,ppss.kr,ygosu.com,tgd.kr#%#//scriptlet("prevent-setTimeout", "eval", "1000")
-ppss.kr,ygosu.com,tgd.kr,inven.co.kr,loawa.com,feedclick.net#%#//scriptlet("prevent-addEventListener", "", "catch_error")
+ppss.kr,ygosu.com,tgd.kr,loawa.com,inven.co.kr,feedclick.net#%#//scriptlet("prevent-setTimeout", "", "10")
 ! PopMagic
 watchfreejavonline.co#%#//scriptlet("abort-current-inline-script", "popMagic.init")
 !

--- a/filters-uBO/scriptlets.txt
+++ b/filters-uBO/scriptlets.txt
@@ -1,8 +1,7 @@
 ! Topics API for advertisement
 ##+js(set, document.browsingTopics, undefined)
 ! Ad-Shield
-inven.co.kr,ppss.kr,ygosu.com,tgd.kr##+js(nostif, eval, 1000)
-ppss.kr,ygosu.com,tgd.kr,inven.co.kr,loawa.com,feedclick.net##+js(aeld, , catch_error)
+ppss.kr,ygosu.com,tgd.kr,loawa.com,inven.co.kr,feedclick.net##+js(nostif, , 10)
 ! PopMagic
 watchfreejavonline.co##+js(acis, popMagic.init)
 !


### PR DESCRIPTION
In #350 , it was too risky to block the method. However, I found that still `nostif` is working.