### PR TITLE
Ad-Shield

### DIFF
--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin. Do not add this filter into your DNS filter.
-! Version: 2022.523.2
+! Version: 2022.523.3
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.523.2
+! Version: 2022.523.3
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filters-AG/antiadblock.txt
+++ b/filters-AG/antiadblock.txt
@@ -30,7 +30,7 @@ kakaotv.daum.net,play-tv.kakao.com,tv.kakao.com#@#.banner_ad
 @@||r-log.dable.io/s/ppss.kr/u/$script,domain=ppss.kr
 @@||adservice.google.*/adsid/integrator.js?domain=loawa.com$script,domain=loawa.com
 @@||googleads.g.doubleclick.net/pagead/$subdocument,domain=loawa.com
-@@||pagead2.googlesyndication.com/getconfig/sodar?$xhr,domain=loawa.com
+@@||pagead2.googlesyndication.com/getconfig/sodar?$xmlhttprequest,domain=loawa.com
 @@||tpc.googlesyndication.com/sodar/sodar2.js$script,domain=loawa.com
 @@$generichide,domain=ppss.kr|ygosu.com|feedclick.net|inven.co.kr|loawa.com
 ! AdGlare Ad Server

--- a/filters-AG/antiadblock.txt
+++ b/filters-AG/antiadblock.txt
@@ -21,16 +21,18 @@ kakaotv.daum.net,play-tv.kakao.com,tv.kakao.com#@#.banner_ad
 @@||clickmon.co.kr/ad_img/$subdocument,domain=ygosu.com
 @@||ad.xc.netinsight.co.kr/xc/h/$subdocument,domain=ygosu.com
 @@||tab2.clickmon.co.kr$script,domain=ygosu.com
-@@||static.dable.io/dist/plugin.min.js$xmlhttprequest,domain=ppss.kr
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ppss.kr
-@@||static.dable.io/dist/plugin.min.js$script,domain=ppss.kr
+@@||static.dable.io/dist/plugin.min.js$script,xmlhttprequest,domain=ppss.kr|loawa.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ppss.kr|loawa.com|feedclick.net
 @@||api.dable.io/plugin/services/ppss.kr/prefs2?$script,domain=ppss.kr
-@@||pagead2.googlesyndication.com/pagead/managed/js/adsense/$script,domain=ppss.kr
+@@||pagead2.googlesyndication.com/pagead/managed/js/adsense/$script,domain=ppss.kr|loawa.com|feedclick.net
 @@||r-log.dable.io/s/ppss.kr/u/$script,domain=ppss.kr
 @@||ad.doubleclick.net/ddm/adj/bkne/bdfs$xmlhttprequest,domain=ppss.kr
 @@||r-log.dable.io/s/ppss.kr/u/$script,domain=ppss.kr
+@@||adservice.google.*/adsid/integrator.js?domain=loawa.com$script,domain=loawa.com
+@@||googleads.g.doubleclick.net/pagead/$subdocument,domain=loawa.com
+@@||pagead2.googlesyndication.com/getconfig/sodar?$xhr,domain=loawa.com
+@@||tpc.googlesyndication.com/sodar/sodar2.js$script,domain=loawa.com
 @@$generichide,domain=ppss.kr|ygosu.com|feedclick.net|inven.co.kr|loawa.com
-ygosu.com,feedclick.net#%#//scriptlet("prevent-fetch", "/doubleclick\.net|static\.dable\.io|adsbygoogle/")
 ! AdGlare Ad Server
 x86.co.kr,luckyquiz3.blogspot.com#%#//scriptlet("abort-current-inline-script", "document.createElement", "hasAdblock")
 !

--- a/filters-AG/antiadblock.txt
+++ b/filters-AG/antiadblock.txt
@@ -33,6 +33,7 @@ kakaotv.daum.net,play-tv.kakao.com,tv.kakao.com#@#.banner_ad
 @@||pagead2.googlesyndication.com/getconfig/sodar?$xmlhttprequest,domain=loawa.com
 @@||tpc.googlesyndication.com/sodar/sodar2.js$script,domain=loawa.com
 @@$generichide,domain=ppss.kr|ygosu.com|feedclick.net|inven.co.kr|loawa.com
+googleads.g.doubleclick.net##html
 ! AdGlare Ad Server
 x86.co.kr,luckyquiz3.blogspot.com#%#//scriptlet("abort-current-inline-script", "document.createElement", "hasAdblock")
 !

--- a/filters-AG/html_filtering.txt
+++ b/filters-AG/html_filtering.txt
@@ -1,2 +1,1 @@
 op.gg,etoland.co.kr,sports.donga.com,mlbpark.donga.com,ppss.kr,ygosu.com,inven.co.kr,tgd.kr$$ad-shield-inventory[tag-content="ad-shield-ads"]
-googleads.g.doubleclick.net##html

--- a/filters-AG/html_filtering.txt
+++ b/filters-AG/html_filtering.txt
@@ -1,1 +1,2 @@
 op.gg,etoland.co.kr,sports.donga.com,mlbpark.donga.com,ppss.kr,ygosu.com,inven.co.kr,tgd.kr$$ad-shield-inventory[tag-content="ad-shield-ads"]
+googleads.g.doubleclick.net##html

--- a/filters-AG/scriptlets.txt
+++ b/filters-AG/scriptlets.txt
@@ -2,6 +2,7 @@
 #%#//scriptlet("set-constant", "document.browsingTopics", "undefined")
 ! Ad-Shield
 dailian.co.kr,ppss.kr,ygosu.com,tgd.kr,loawa.com,inven.co.kr,feedclick.net#%#//scriptlet("prevent-setTimeout", "", "10")
+ppss.kr#%#//scriptlet("abort-on-property-read", "document.querySelectorAll")
 ! PopMagic
 watchfreejavonline.co#%#//scriptlet("abort-current-inline-script", "popMagic.init")
 !

--- a/filters-uBO/antiadblock.txt
+++ b/filters-uBO/antiadblock.txt
@@ -21,16 +21,18 @@ kakaotv.daum.net,play-tv.kakao.com,tv.kakao.com#@#.banner_ad
 @@||clickmon.co.kr/ad_img/$frame,domain=ygosu.com
 @@||ad.xc.netinsight.co.kr/xc/h/$frame,domain=ygosu.com
 @@||tab2.clickmon.co.kr$script,domain=ygosu.com
-@@||static.dable.io/dist/plugin.min.js$xhr,domain=ppss.kr
-@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ppss.kr
-@@||static.dable.io/dist/plugin.min.js$script,domain=ppss.kr
+@@||static.dable.io/dist/plugin.min.js$script,xhr,domain=ppss.kr|loawa.com
+@@||pagead2.googlesyndication.com/pagead/js/adsbygoogle.js$script,domain=ppss.kr|loawa.com|feedclick.net
 @@||api.dable.io/plugin/services/ppss.kr/prefs2?$script,domain=ppss.kr
-@@||pagead2.googlesyndication.com/pagead/managed/js/adsense/$script,domain=ppss.kr
+@@||pagead2.googlesyndication.com/pagead/managed/js/adsense/$script,domain=ppss.kr|loawa.com|feedclick.net
 @@||r-log.dable.io/s/ppss.kr/u/$script,domain=ppss.kr
 @@||ad.doubleclick.net/ddm/adj/bkne/bdfs$xhr,domain=ppss.kr
 @@||r-log.dable.io/s/ppss.kr/u/$script,domain=ppss.kr
+@@||adservice.google.*/adsid/integrator.js?domain=loawa.com$script,domain=loawa.com
+@@||googleads.g.doubleclick.net/pagead/$frame,domain=loawa.com
+@@||pagead2.googlesyndication.com/getconfig/sodar?$xhr,domain=loawa.com
+@@||tpc.googlesyndication.com/sodar/sodar2.js$script,domain=loawa.com
 @@$ghide,domain=ppss.kr|ygosu.com|feedclick.net|inven.co.kr|loawa.com
-ygosu.com,feedclick.net##+js(no-fetch-if, /doubleclick\.net|static\.dable\.io|adsbygoogle/)
 ! AdGlare Ad Server
 x86.co.kr,luckyquiz3.blogspot.com##+js(acis, document.createElement, hasAdblock)
 !

--- a/filters-uBO/scriptlets.txt
+++ b/filters-uBO/scriptlets.txt
@@ -2,6 +2,7 @@
 ##+js(set, document.browsingTopics, undefined)
 ! Ad-Shield
 dailian.co.kr,ppss.kr,ygosu.com,tgd.kr,loawa.com,inven.co.kr,feedclick.net##+js(nostif, , 10)
+ppss.kr##+js(aopr, document.querySelectorAll)
 ! PopMagic
 watchfreejavonline.co##+js(acis, popMagic.init)
 !


### PR DESCRIPTION
Fixed Ad-Shield on `ppss.kr`, `ygosu.com`, `loawa.com` and `feedclick.net`

Also ` googleads.g.doubleclick.net##html` got readded to counter the leftovers on loawa (only for AG, uBO have already filter for that)