### PR TITLE
Ad-Shield

### DIFF
--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin. Do not add this filter into your DNS filter.
-! Version: 2022.524.6
+! Version: 2022.524.7
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.524.6
+! Version: 2022.524.7
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filters-AG/html_filtering.txt
+++ b/filters-AG/html_filtering.txt
@@ -1,1 +1,2 @@
 op.gg,etoland.co.kr,sports.donga.com,mlbpark.donga.com,ppss.kr,ygosu.com,inven.co.kr,tgd.kr$$ad-shield-inventory[tag-content="ad-shield-ads"]
+ppss.kr,ygosu.com,tgd.kr,inven.co.kr,loawa.com,feedclick.net,dailian.co.kr$$script[tag-content="adshield_analytics_entrypoint"]

--- a/filters-uBO/html_filtering.txt
+++ b/filters-uBO/html_filtering.txt
@@ -1,1 +1,2 @@
 op.gg,etoland.co.kr,sports.donga.com,mlbpark.donga.com,ppss.kr,ygosu.com,inven.co.kr,tgd.kr##^ad-shield-inventory
+ppss.kr,ygosu.com,tgd.kr,inven.co.kr,loawa.com,feedclick.net,dailian.co.kr##^script:has-text(adshield_analytics_entrypoint)


### PR DESCRIPTION
Hello, i know Ad-Shield have 2 scripts. The new one which get updated and a older one which appears after a few reloads/clicking on other links. Removing the old script with HTML filter does not affect the images but it maked the browser not executing crap scripts

<details>
<summary> screenshot </summary>

<img width="1081" alt="Unbenannt" src="https://user-images.githubusercontent.com/48647394/170057888-3ce8b9f8-79a6-41c8-a2ce-0d6a8841c338.PNG">

</details>