### PR TITLE
Fix loawa. com breakage

### DIFF
--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin. Do not add this filter into your DNS filter.
-! Version: 2022.527.1
+! Version: 2022.527.2
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.527.1
+! Version: 2022.527.2
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -1,3 +1,6 @@
+! Ad-Shield
+loawa.com##ad-shield-inventory
+!
 ! ##div[id^="ad_"]
 m.edaily.co.kr,hani.co.kr,m.sedaily.com,m.thisisgame.com,planet-times.com,m.10000recipe.com,pandora.tv,mobile.newsis.com,zdnet.co.kr,fnnews.com,land.hankyung.com,mania.kr,mosen.mt.co.kr,ruliweb.com##div[id^="ad_"]
 ! ##div[class$="_ad"]


### PR DESCRIPTION
When adshield is not active the top element not getting moved correctly on subpages `https://loawa.com/char/%EB%B9%88%EC%84%B8%EB%A1%9C%EC%9D%B4` and blocks the search bar.

`pointer-events: none` doesn’t work it get detected