### PR TITLE
coupang new ad parameter

### DIFF
--- a/filter-uBO.txt
+++ b/filter-uBO.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR uBO
 ! Description: List-KR for uBlock Origin. Do not add this filter into your DNS filter.
-! Version: 2022.608.6
+! Version: 2022.608.7
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.608.6
+! Version: 2022.608.7
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filters-share/specific_URL.txt
+++ b/filters-share/specific_URL.txt
@@ -107,6 +107,7 @@
 ||mdjournal.kr/banner/
 ||mdjournal.kr/bannerManager/
 ||coupang.com/*&addtag=*ptag=*&redirect=landing&traceid=*&placementid=*&impressionid=&campaigntype=$document,popup
+||coupang.com/*&addtag=*ptag=*wPcid=*&wRef=*&redirect=landing&traceid=*&subid$document,popup
 ||startupn.kr/adManager/css/adManager.css
 ||startupn.kr/bannerpop/uploads/
 ||dr9xthplobr1x.cloudfront.net/smart/MWEB/img/


### PR DESCRIPTION
`||coupang.com/*&addtag=*ptag=*&redirect=landing&traceid=*&placementid=*&impressionid=&campaigntype=$document,popup` does not cover all thats why a added a second one