### PR TITLE
leftover: adguard — adcrap

### DIFF
--- a/filter.txt
+++ b/filter.txt
@@ -1,6 +1,6 @@
 ! Title: List-KR
 ! Description: List-KR for AdGuard. Do not add this filter into your DNS filter.
-! Version: 2022.610.1
+! Version: 2022.610.2
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://github.com/List-KR/List-KR/issues/223

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -1,5 +1,9 @@
 ! Ad-Shield
 inven.co.kr,loawa.com,ppss.kr,feedclick.net,ygosu.com##style+div:nth-last-child(1)
+! >>>>> Ad-Shield AdGuard Fix
+inven.co.kr##div.right-menu
+loawa.com###main>.row>.col:first-child
+! <<<<<
 !
 ! ##div[id^="ad_"]
 m.edaily.co.kr,hani.co.kr,m.sedaily.com,m.thisisgame.com,planet-times.com,m.10000recipe.com,pandora.tv,mobile.newsis.com,zdnet.co.kr,fnnews.com,land.hankyung.com,mania.kr,mosen.mt.co.kr,ruliweb.com##div[id^="ad_"]

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -2,7 +2,9 @@
 inven.co.kr,loawa.com,ppss.kr,feedclick.net,ygosu.com##style+div:nth-last-child(1)
 !#if adguard
 inven.co.kr##div.right-menu
-loawa.com###main>.row>.col:first-child
+loawa.com##main div[class*="p-0 m-0 mb-2 d-none d-md-block text-center"]
+loawa.com##div[id$="_v"]
+loawa.com##div[id$="_v2"]
 !#endif
 !
 ! ##div[id^="ad_"]

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -1,9 +1,9 @@
 ! Ad-Shield
 inven.co.kr,loawa.com,ppss.kr,feedclick.net,ygosu.com##style+div:nth-last-child(1)
-! >>>>> Ad-Shield AdGuard Fix
+!#if adguard
 inven.co.kr##div.right-menu
 loawa.com###main>.row>.col:first-child
-! <<<<<
+!#endif
 !
 ! ##div[id^="ad_"]
 m.edaily.co.kr,hani.co.kr,m.sedaily.com,m.thisisgame.com,planet-times.com,m.10000recipe.com,pandora.tv,mobile.newsis.com,zdnet.co.kr,fnnews.com,land.hankyung.com,mania.kr,mosen.mt.co.kr,ruliweb.com##div[id^="ad_"]


### PR DESCRIPTION
This fixes leftover ads for AdGuard on adcrap sites. Not required for uBO. Fixes https://github.com/List-KR/List-KR/issues/277#issuecomment-1152101465