### PR TITLE
해시넷 -> 위키원(wiki1.kr) 사이트 도메인 변경 반영

### DIFF
--- a/filter-AdGuard.txt
+++ b/filter-AdGuard.txt
@@ -1,7 +1,7 @@
 [AdGuard]
 ! Title: List-KR for AdGuard
 ! Description: List-KR for AdGuard. Maintained by the adblock community and AdGuard.
-! Version: 2025.0213.2
+! Version: 2025.0214.0
 ! Expires: 1 day
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://list-kr-community.pages.dev/docs/

--- a/filter-uBlockOrigin.txt
+++ b/filter-uBlockOrigin.txt
@@ -1,7 +1,7 @@
 [uBlock Origin]
 ! Title: List-KR for uBlock Origin
 ! Description: List-KR for uBlock Origin. Maintained by the adblock community and AdGuard.
-! Version: 2025.0213.2
+! Version: 2025.0214.0
 ! Expires: 12 hours
 ! Homepage: https://github.com/List-KR/List-KR
 ! Support: https://list-kr-community.pages.dev/docs/

--- a/filters-share/specific_ELEMHIDE.txt
+++ b/filters-share/specific_ELEMHIDE.txt
@@ -337,7 +337,7 @@ shopping.interpark.com##.AdvertisingList
 shopping.interpark.com###btnlist > #listChoiceScope
 shopping.interpark.com##.productSortingList > .choice
 shopping.interpark.com##.productListWrap > #serviceKeywordId
-hash.kr##table[border="0"] > tbody > tr > td:not(td > div:not(div.noresize) + b > a:not([target="_blank"]))
+wiki1.kr##table:has(.noresize img[alt*="배너"])
 mlbpark.donga.com##.left_cont > div[style^="width:"]
 ruliweb.com##.adrr
 forwarder.kr###aside > div[style^="background-color:"]
@@ -782,7 +782,7 @@ m.mimint.co.kr,m.dailian.co.kr,uwayapply.com,ypbooks.co.kr##div[id$="Banner"]
 ypbooks.co.kr##div[style]#cenArea > .today
 lawtalknews.co.kr##.tdn-inventory
 www.tmon.co.kr##ul#_dealListContainer.list > li.item.type_admon[data-maincategoryno]
-wiki.hash.kr##.wkbn_bk.tp
+wiki1.kr##.wkbn_bk.tp
 m.eye.seoul.co.kr,m.seoul.co.kr###Article > .Line_gray ~ div[style]:not([class]):not([id])
 m.fpn119.co.kr###top_src > div[style]
 fpn119.co.kr###r_aside > center > .bn
@@ -849,8 +849,8 @@ cmobile.g-enews.com,m.g-enews.com##.mwrap > div[style]:not([class])
 cmobile.g-enews.com,asiatime.co.kr,m.g-enews.com##div[class*="AD"]
 hyundaenews.com##a[href^="/ad_link.php?"]
 quasarplay.com##[class^="img_wrapper"]
-hash.kr##div[class^="bann_"]
-hash.kr##div[class^="bnn_"]
+wiki1.kr##div[class^="bann_"]
+wiki1.kr##div[class^="bnn_"]
 all-mice.co.kr###main_visual
 hotword.site,g-enews.com,cgv.co.kr##div[class$="ad"][style]
 cgv.co.kr##div[id$="_PlaceHolderContent_divMovieSelection_wrap"][class]

--- a/filters-share/specific_URL.txt
+++ b/filters-share/specific_URL.txt
@@ -130,8 +130,8 @@
 ||shopapi.interpark.com/advertisement/
 ||shopping.interpark.com/resources/js/plugin/powerLinkLoad.js
 ||openimage.interpark.com/dia/images/
-||hash.kr/images/main/*_banner
-||wiki.hash.kr/images/thumb/e/ef/
+||wiki1.kr/images/main/*_banner
+||wiki1.kr/images/thumb/e/ef/
 ||ruliweb.com/banneriframe
 ||forwarder.kr/data/file/banner/
 /^https?:\/\/5l\.co\.kr\/img\/[0-9A-z]+_[0-9]+X[0-9]+\./$domain=5l.co.kr


### PR DESCRIPTION
> 2024년 6월 10일자로 해시넷 사이트 이름을 '위키원'(wiki1)으로 변경합니다.
> https://wiki1.kr/index.php/%EC%9C%84%ED%82%A4%EC%9B%90:%EA%B3%B5%EC%A7%80_2024-06-10

위키원은 기존 해시넷(hash.kr)이 2024년 6월 10일부로 이름바꾼 사이트입니다. 이에 맞춰 필터에 명시한 도메인 wiki.hash.kr 를 새 주소인 wiki1.kr 로 변경하였습니다.

또한, specific_ELEMHIDE.txt 에 있던 `hash.kr##table[border="0"] > tbody > tr > td:not(td > div:not(div.noresize) + b > a:not([target="_blank"]))` 의 경우 대문 페이지에 (광고가 아닌) 일부 요소가 숨겨지는 현상을 발견하여 제가 임의로 고쳤습니다.