### PR TITLE
annoyance: com.kakao.talk

### DIFF
--- a/annoyance/filters-AG/mobile/android/android_app.txt
+++ b/annoyance/filters-AG/mobile/android/android_app.txt
@@ -1,1 +1,4 @@
-!
+! KakaoTalk - 소식/숏폼/쇼핑 탭 차단
+||talk-pilsner.kakao.com^$app=com.kakao.talk
+||play.kakao.com^$app=com.kakao.talk
+||shopper.kakao.com^$app=com.kakao.talk

--- a/annoyance/filters-AG/mobile/ios/ios_app.txt
+++ b/annoyance/filters-AG/mobile/ios/ios_app.txt
@@ -1,4 +1,4 @@
 ! KakaoTalk - 소식/숏폼/쇼핑 탭 차단
-||talk-pilsner.kakao.com^$app=com.kakao.talk
-||play.kakao.com^$app=com.kakao.talk
-||shopper.kakao.com^$app=com.kakao.talk
+||talk-pilsner.kakao.com
+||play.kakao.com
+||shopper.kakao.com

--- a/annoyance/filters-AG/mobile/ios/ios_app.txt
+++ b/annoyance/filters-AG/mobile/ios/ios_app.txt
@@ -1,1 +1,4 @@
-!
+! KakaoTalk - 소식/숏폼/쇼핑 탭 차단
+||talk-pilsner.kakao.com^$app=com.kakao.talk
+||play.kakao.com^$app=com.kakao.talk
+||shopper.kakao.com^$app=com.kakao.talk


### PR DESCRIPTION
카카오톡 앱 대개편 이후 추가된 소식, 숏폼, 쇼핑 탭의 도메인 차단 규칙 추가를 Draft PR로 제안드립니다.

국회 국정감사에서 언급될 정도로 큰 반발로 인해 지난 연말에 친구 화면이 기본으로 돌아오고 소식 탭이 서브 탭으로 이동했지만, 그 외 탭은 그대로 남아있어 여전히 거슬립니다. 이에 개인적으로 적용하던 차단 목록을 공유하게 되었습니다.

관련 영상 - 결국 국민 기만?..카카오의 오만한 답변 [이 장면] / YTN: https://youtu.be/POncM276-P4

- 소식 탭: talk-pilsner.kakao.com
- 숏폼 탭: play.kakao.com
- 쇼핑 탭: shopper.kakao.com

<details>
<summary>각 탭 별 스크린샷</summary>

| 소식 탭 | 숏폼 탭 | 쇼핑 탭 |
| :--: | :--: | :--: |
| ![소식 탭](https://github.com/user-attachments/assets/f3e00ce2-d697-4cf3-9aa1-307a9a72a433) | ![숏폼 탭](https://github.com/user-attachments/assets/d0971001-bc9a-431b-9f72-a924bd571031) | ![쇼핑 탭](https://github.com/user-attachments/assets/a5c8534f-fbbc-4b40-8f79-040b5d4743ba) |

</details>

---

annoyance 카테고리의 모바일 Android/iOS 앱 필터 규칙이 비어있어서 의아했지만, 우선 AdGuard 필터 컨벤션에 맞춰 해당 디렉토리에 추가했습니다. (third-party ads와 self-promotion 모두 해당하지 않아 annoyance로 분류)