### PR TITLE
Revert "annoyance: com.kakao.talk (#1019)"

### DIFF
--- a/annoyance/filters-AG/mobile/android/android_app.txt
+++ b/annoyance/filters-AG/mobile/android/android_app.txt
@@ -1,4 +1,1 @@
-! KakaoTalk - 소식/숏폼/쇼핑 탭 차단
-||talk-pilsner.kakao.com^$app=com.kakao.talk
-||play.kakao.com^$app=com.kakao.talk
-||shopper.kakao.com^$app=com.kakao.talk
+!

--- a/annoyance/filters-AG/mobile/ios/ios_app.txt
+++ b/annoyance/filters-AG/mobile/ios/ios_app.txt
@@ -1,4 +1,1 @@
-! KakaoTalk - 소식/숏폼/쇼핑 탭 차단
-||talk-pilsner.kakao.com
-||play.kakao.com
-||shopper.kakao.com
+!


### PR DESCRIPTION
This reverts commit dc5785efb71c24888b97cb7cba410bc146769f92.

작업 이후 처음부터 다시 검수해본 결과, 두 가지 이유로 되돌릴 필요를 찾았습니다.

- talk-pilsner.kakao.com: 카카오 이모티콘 상점, 메시지 리액션 등 주요 기능에서도 사용됨.

  <details><summary>screenshot</summary>
    
  | 채팅 UI - 이모티콘 검색 | 채팅 UI - 미니 이모티콘 목록 | 카카오 이모티콘 별도 스크린<br/> (Bottom Drawer U 형태I) |
  |:--:|:--:|:--:|
  | <img alt="" src="https://github.com/user-attachments/assets/89d88689-5df1-41e3-a27f-1059233102af" /> |  <img alt="" src="https://github.com/user-attachments/assets/29da5ddb-90f7-4732-8b42-ad5206c6c26c" /> | <img alt="" src="https://github.com/user-attachments/assets/ce0ea3c7-1357-478d-9e3d-8ea26da031bf" /> |

   </details>

- shopper.kakao.com: 쇼핑 탭이 메신저 사용 흐름에 거슬리는지 애매함. 

  숏폼과 달리 **직접 선택해야 노출되고**, 쇼핑을 즐기는 사용자 층의 경우 오히려 유용할 수 있어 불호가 다를 것으로 예상함.

   <details><summary>screenshot</summary>
     <img width="280" alt="" src="https://github.com/user-attachments/assets/e7ff7281-eea0-426e-9023-407683dfccc7" />
   </details>


요약: **소식 탭의 세부 엔드포인트를 명확히 파악한 이후에** 다시 제안하겠습니다.