### PR TITLE
fix #229990 ytn.co.kr

### DIFF
--- a/filterslists/adblocking/filters-AG/extended_css_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-AG/extended_css_ELEMHIDE.txt
@@ -1,3 +1,4 @@
+m.ytn.co.kr#?#div:has(> h2:contains(실시간 정보))
 vortexgaming.io#?#div[class^="PostAsideCardList_card_list_inner__"]  > div[class^="PostAsideCardList_card__"]:has(div[class^="PostAsideCardList_close__"]:contains(AD))
 pedia.watcha.com#?#div[class] > section[class*=" "]:has(> section > a h3 > p:contains( · AD))
 m.ruliweb.com#?#.TimelineHeaderMargin ~ div .infinite-scroll-component > div:has(span[style*="max-height:"]:contains(AD))

--- a/filterslists/adblocking/filters-AG/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-AG/specific_ELEMHIDE.txt
@@ -1,3 +1,15 @@
+!#if (adguard_ext_safari || adguard_app_ios)
+m.ytn.co.kr#@#.ad_1200
+m.ytn.co.kr#@#.ad_300
+m.ytn.co.kr#@#div[class*="YTN_CSA_mainbnr"]
+m.ytn.co.kr#@#.recomm_news_slider.YTN_CSA_editorrecomm
+ytn.co.kr##.ad_1200
+m.ytn.co.kr#@##zone2 + div:has(iframe[name^="AdServerChange"])
+ytn.co.kr##.ad_300
+ytn.co.kr##div[class*="YTN_CSA_mainbnr"]
+ytn.co.kr##.recomm_news_slider.YTN_CSA_editorrecomm
+ytn.co.kr###zone2 + div:has(iframe[name^="AdServerChange"])
+!#endif
 namu.wiki,~board.namu.wiki##div[class] ~ div div + *[class]:not([class*=" "]) *[class*=" "] div[class]:has(> iframe[id^="google_ads_"])
 namu.wiki,~board.namu.wiki##div[class] ~ div div + *[class]:not([class*=" "]) *[class*=" "] div[class]:has(iframe[src*="arca.live/external/callad"])
 namu.wiki,~board.namu.wiki##*[class]:not([class*=" "]) > div[class]:not([class*=" "]) ~ *:not([class]) > *[class]:has(iframe[id^="google_ads_iframe_"])

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -50,6 +50,7 @@ ygosunews.com#$#body { padding-top: 0px !important; }
 www.auction.co.kr#$##allKillItemList > .item_list_wrap { width: 100% !important; }
 yes24.com#$##ySContent .loginCont { margin-left: 200px !important; }
 yes24.com#$#.mContRT .mbnZone { left: 94.5px !important; }
+~m.ytn.co.kr,ytn.co.kr#$#.editor_news.YTN_CSA_editorrecomm { width: initial !important; flex-shrink: initial !important; }
 m.ytn.co.kr#$##entFlick { height: auto !important; }
 yes24.com#$##yHeader .yesSearch .key_latest .lastest_word { width: 100% !important; }
 yes24.com#$##yWelMid .yWelNowBook { width: 100% !important; }

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1167,6 +1167,16 @@ gginews.co.kr##center > .bn
 mangacat.cc##.col-md-3.at-col.at-side > .row.fix-gutters-5
 mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
+m.ytn.co.kr##.iwm_ba
+m.ytn.co.kr##.bx_ad
+~m.ytn.co.kr,ytn.co.kr##.ad_1200
+~m.ytn.co.kr,ytn.co.kr##.ad_300
+~m.ytn.co.kr,ytn.co.kr#?#:matches-attr(class=/top_banner\d/):matches-attr(class=/YTN_CSA_mainbnr\d/)
+~m.ytn.co.kr,ytn.co.kr##.recomm_news_slider.YTN_CSA_editorrecomm
+~m.ytn.co.kr,ytn.co.kr###zone2 + div:has(iframe[name^="AdServerChange"])
+ytn.co.kr##li.pnews:has(> .iframe[src^="https://ad.smartinmedia.co.kr/cgi-bin/PelicanC.dll"])
+ytn.co.kr##li.pnews:not(:has(*))
+ytn.co.kr##div:has(> .iframe[src^="https://ad.smartinmedia.co.kr/cgi-bin/PelicanC.dll"])
 ytn.co.kr##.ad_newsview_text
 ytn.co.kr##.ad_newsview_bottom
 nts.go.kr##.blockUI.blockOverlay

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1169,14 +1169,12 @@ mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
 m.ytn.co.kr##.iwm_ba
 m.ytn.co.kr##.bx_ad
+m.ytn.co.kr##li.pnews:not(:has(*))
 ~m.ytn.co.kr,ytn.co.kr##.ad_1200
 ~m.ytn.co.kr,ytn.co.kr##.ad_300
 ~m.ytn.co.kr,ytn.co.kr#?#:matches-attr(class=/top_banner\d/):matches-attr(class=/YTN_CSA_mainbnr\d/)
 ~m.ytn.co.kr,ytn.co.kr##.recomm_news_slider.YTN_CSA_editorrecomm
 ~m.ytn.co.kr,ytn.co.kr###zone2 + div:has(iframe[name^="AdServerChange"])
-ytn.co.kr##li.pnews:has(> .iframe[src^="https://ad.smartinmedia.co.kr/cgi-bin/PelicanC.dll"])
-ytn.co.kr##li.pnews:not(:has(*))
-ytn.co.kr##div:has(> .iframe[src^="https://ad.smartinmedia.co.kr/cgi-bin/PelicanC.dll"])
 ytn.co.kr##.ad_newsview_text
 ytn.co.kr##.ad_newsview_bottom
 nts.go.kr##.blockUI.blockOverlay

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1177,7 +1177,11 @@ m.ytn.co.kr#?#div:has(> h2:contains(실시간 정보))
 m.ytn.co.kr##li.pnews:not(:has(*))
 ~m.ytn.co.kr,ytn.co.kr##.ad_1200
 ~m.ytn.co.kr,ytn.co.kr##.ad_300
-~m.ytn.co.kr,ytn.co.kr#?#:matches-attr(class=/top_banner\d/):matches-attr(class=/YTN_CSA_mainbnr\d/)
+!#if ext_ublock
+~m.ytn.co.kr,ytn.co.kr##div:is([class~="top_banner1"],[class~="top_banner2"],[class~="top_banner3"],[class~="top_banner4"],[class~="top_banner5"])[class*="YTN_CSA_mainbnr"]
+!#else
+~m.ytn.co.kr,ytn.co.kr#?#div:matches-attr(class=/top_banner\d/):matches-attr(class=/YTN_CSA_mainbnr\d/)
+!#endif
 ~m.ytn.co.kr,ytn.co.kr##.recomm_news_slider.YTN_CSA_editorrecomm
 ~m.ytn.co.kr,ytn.co.kr###zone2 + div:has(iframe[name^="AdServerChange"])
 ytn.co.kr##.ad_newsview_text

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1167,8 +1167,8 @@ gginews.co.kr##center > .bn
 mangacat.cc##.col-md-3.at-col.at-side > .row.fix-gutters-5
 mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
-m.ytn.co.kr##div[class^="newsview_ad_"]
-m.ytn.co.kr##div[class^="text_ad_"]
+ytn.co.kr##.ad_newsview_text
+ytn.co.kr##.ad_newsview_bottom
 nts.go.kr##.blockUI.blockOverlay
 nts.go.kr##.blockUI.blockMsg.blockPage
 noonnu.cc##div[data-fonts-target="fontsContainer"] > div.group.min-h-auto:not(.duration-300):not(.justify-between)

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1168,7 +1168,6 @@ mangacat.cc##.col-md-3.at-col.at-side > .row.fix-gutters-5
 mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
 m.ytn.co.kr##.iwm_ba
-m.ytn.co.kr##.bx_ad
 m.ytn.co.kr##li.pnews:not(:has(*))
 ~m.ytn.co.kr,ytn.co.kr##.ad_1200
 ~m.ytn.co.kr,ytn.co.kr##.ad_300

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1168,7 +1168,7 @@ mangacat.cc##.col-md-3.at-col.at-side > .row.fix-gutters-5
 mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
 m.ytn.co.kr##.iwm_ba
-m.ytn.co.kr##li.pnews:not(:has(*))
+m.ytn.co.kr##li.pnews:empty
 ~m.ytn.co.kr,ytn.co.kr##.ad_1200
 ~m.ytn.co.kr,ytn.co.kr##.ad_300
 ~m.ytn.co.kr,ytn.co.kr##div[class*="YTN_CSA_mainbnr"]

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1169,19 +1169,10 @@ mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
 m.ytn.co.kr##.iwm_ba
 m.ytn.co.kr##.bx_ad
-!#if ext_ublock
-m.ytn.co.kr#?#div:has(> h2:has-text(실시간 정보))
-!#else
-m.ytn.co.kr#?#div:has(> h2:contains(실시간 정보))
-!#endif
 m.ytn.co.kr##li.pnews:not(:has(*))
 ~m.ytn.co.kr,ytn.co.kr##.ad_1200
 ~m.ytn.co.kr,ytn.co.kr##.ad_300
-!#if ext_ublock
-~m.ytn.co.kr,ytn.co.kr##div:is([class~="top_banner1"],[class~="top_banner2"],[class~="top_banner3"],[class~="top_banner4"],[class~="top_banner5"])[class*="YTN_CSA_mainbnr"]
-!#else
-~m.ytn.co.kr,ytn.co.kr#?#div:matches-attr(class=/top_banner\d/):matches-attr(class=/YTN_CSA_mainbnr\d/)
-!#endif
+~m.ytn.co.kr,ytn.co.kr##div[class*="YTN_CSA_mainbnr"]
 ~m.ytn.co.kr,ytn.co.kr##.recomm_news_slider.YTN_CSA_editorrecomm
 ~m.ytn.co.kr,ytn.co.kr###zone2 + div:has(iframe[name^="AdServerChange"])
 ytn.co.kr##.ad_newsview_text

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1169,6 +1169,11 @@ mangacat.cc##img[src^="/mainhover/"]
 mangacat.cc##.basic-banner.row.row-10
 m.ytn.co.kr##.iwm_ba
 m.ytn.co.kr##.bx_ad
+!#if ext_ublock
+m.ytn.co.kr#?#div:has(> h2:has-text(실시간 정보))
+!#else
+m.ytn.co.kr#?#div:has(> h2:contains(실시간 정보))
+!#endif
 m.ytn.co.kr##li.pnews:not(:has(*))
 ~m.ytn.co.kr,ytn.co.kr##.ad_1200
 ~m.ytn.co.kr,ytn.co.kr##.ad_300

--- a/filterslists/adblocking/filters-uBO/extended_css_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-uBO/extended_css_ELEMHIDE.txt
@@ -1,3 +1,4 @@
+m.ytn.co.kr#?#div:has(> h2:has-text(실시간 정보))
 vortexgaming.io#?#div[class^="PostAsideCardList_card_list_inner__"]  > div[class^="PostAsideCardList_card__"]:has(div[class^="PostAsideCardList_close__"]:has-text(AD))
 pedia.watcha.com#?#div[class] > section[class*=" "]:has(> section > a h3 > p:has-text( · AD))
 m.ruliweb.com#?#.TimelineHeaderMargin ~ div .infinite-scroll-component > div:has(span[style*="max-height:"]:has-text(AD))


### PR DESCRIPTION
fix https://github.com/AdguardTeam/AdguardFilters/issues/229990

### Note: Tweak the main page CSS



Updated the CSS code in <code>specific_CSS.txt</code> to adjust the fill width for the homepage news items section.

| Before | Applied |
|-|-|
| <img alt="Screenshot 2026-04-28 at 10 59 12 PM" src="https://github.com/user-attachments/assets/0440ec75-92e4-4a0b-8a7b-277996b4a9b4" /> | <img alt="Screenshot 2026-04-28 at 10 58 35 PM" src="https://github.com/user-attachments/assets/3c8fa817-ae36-4f16-b580-fe0ff9eb7569" /> |

