### PR TITLE
leftover: tenasia.co.kr

### DIFF
--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -85,6 +85,9 @@ kyobobook.co.kr##main.min-h-\[calc\(100vh-80px\)\] > .h-\[180px\]
 kyobobook.co.kr##main.min-h-\[calc\(100vh-80px\)\] > .h-\[150px\]
 kyobobook.co.kr##.wpromo-banner
 kyobobook.co.kr##.fly_menu_banner
+tenasia.co.kr##.ad-area-wrap
+tenasia.co.kr##.ad-bottom-fix
+tenasia.co.kr##div:has(> [id^="dablewidget"])
 mvod.jtbc.co.kr##div[class^="iframe_"][class$="_ad"]
 app.pizzaalvolo.co.kr##div[class^="css-"][style^="gap: "] > div[tabindex="0"]:has(div[style^="position: absolute; right:"])
 etoland.co.kr##div[class^="etoad_"]


### PR DESCRIPTION
광고 칸 여백 제거
아래는 전후 비교 스크린샷입니다.
모바일 버전 광고 여백 제거 또한 포함됩니다.


<img width="818" height="1672" alt="IMG_1" src="https://github.com/user-attachments/assets/01f88f26-dd2a-46bc-a054-a1ce574f63ea" />
<img width="803" height="1921" alt="IMG_2" src="https://github.com/user-attachments/assets/ce67aad5-d476-45c0-b2a3-8a2d962e1f59" />
