### PR TITLE
annoyance: www.naver.com

### DIFF
--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1372,6 +1372,7 @@ m.dcinside.com##ul.detail-top-lst.trend
 clien.net##div:has(> div[class="ad_banner"])
 koreaminecraft.net##tr.notice:not(:has(.wst_member_title))
 kio.ac##main > div:has(> div > div > a > img)
+www.naver.com###whale-banner
 !
 ! DOMAIN-REFRESHER: START
 !

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1372,7 +1372,6 @@ m.dcinside.com##ul.detail-top-lst.trend
 clien.net##div:has(> div[class="ad_banner"])
 koreaminecraft.net##tr.notice:not(:has(.wst_member_title))
 kio.ac##main > div:has(> div > div > a > img)
-www.naver.com###whale-banner
 !
 ! DOMAIN-REFRESHER: START
 !

--- a/filterslists/annoyance/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/annoyance/filters-share/specific_ELEMHIDE.txt
@@ -1,1 +1,1 @@
-!
+www.naver.com###whale-banner


### PR DESCRIPTION
네이버 상단에 보여지는 웨일 배너를 숨겼습니다.

로컬스토리지에 `whaleBannerHideUntilV2`=timestamp 형태로 저장하는 것도 확인이 됩니다만, 지금은 elemhide로 충분할 듯 싶습니다.

<img width="1097" height="657" alt="image" src="https://github.com/user-attachments/assets/2c177793-6443-44de-a732-5335a384288a" />
