### PR TITLE
leftover: m.etoday.co.kr

### DIFF
--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -1013,6 +1013,7 @@ newsis.com##div[id][style~="height:100px;"]
 newsis.com##iframe[src^="/view/ad/"]
 newsis.com##div[class^="w_header_"]:nth-child(1)
 newsis.com##table[class*="Ad"]
+m.etoday.co.kr##section > div[style*="height:250px"]
 jootc.com,funissu.com##aside[id^="ai_widget-"]
 poro.gg##div[class^="flex"][class$="h-[250px]"]
 bada.io##div[id*="amazon_shopping"]


### PR DESCRIPTION
fix #1046
필터 적용 후 아래 영역이 사라집니다.

<img width="1225" height="1364" alt="screenshot" src="https://github.com/user-attachments/assets/52f8106b-c343-4725-ba40-b15e63731978" />
