### PR TITLE
advert: chzzk.naver.com self-prom top banner

### DIFF
--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -4,7 +4,7 @@ chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_filter_"] { top: 51px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_tab_"] { top: 51px !important; }
-chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > main > div[style^="top:"] { top: 124px !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > main > div[class^="_wrapper_"] { top: 124px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_area_"] > #videos-PANEL > header { top: 94px !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -3,6 +3,7 @@ chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar { transform: translateY(60px) !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_filter_"] { top: 51px !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > main > div[style^="top:"] { top: 124px !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }
 damoang.net#$#.mb-6.grid-cols-1.gap-4.sm\:grid-cols-3 { grid-template-columns: auto !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -2,6 +2,7 @@ chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header { transform: initial !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar { transform: translateY(60px) !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_filter_"] { top: 51px !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }
 damoang.net#$#.mb-6.grid-cols-1.gap-4.sm\:grid-cols-3 { grid-template-columns: auto !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -3,6 +3,7 @@ chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar { transform: translateY(60px) !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_filter_"] { top: 51px !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_tab_"] { top: 51px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > main > div[style^="top:"] { top: 124px !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -1,3 +1,4 @@
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) { display: none !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header { transform: initial !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar { transform: translateY(60px) !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -1,3 +1,6 @@
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header { transform: initial !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar { transform: translateY(60px) !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }
 damoang.net#$#.mb-6.grid-cols-1.gap-4.sm\:grid-cols-3 { grid-template-columns: auto !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -5,6 +5,7 @@ chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_filter_"] { top: 51px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_tab_"] { top: 51px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > main > div[style^="top:"] { top: 124px !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_area_"] > #videos-PANEL > header { top: 94px !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }
 damoang.net#$#.mb-6.grid-cols-1.gap-4.sm\:grid-cols-3 { grid-template-columns: auto !important; }

--- a/filterslists/adblocking/filters-share/specific_CSS.txt
+++ b/filterslists/adblocking/filters-share/specific_CSS.txt
@@ -5,7 +5,7 @@ chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_filter_"] { top: 51px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_tab_"] { top: 51px !important; }
 chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > main > div[class^="_wrapper_"] { top: 124px !important; }
-chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_area_"] > #videos-PANEL > header { top: 94px !important; }
+chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body > div[class^="_container_"] > section > div[class^="_area_"] > div[role="tabpanel"] > header { top: 94px !important; }
 tenbizt.com#$##fv-ol-wrap { display: none !important; }
 tenbizt.com#$#body { overflow: initial !important; position: initial !important; top: initial !important; }
 damoang.net#$#.mb-6.grid-cols-1.gap-4.sm\:grid-cols-3 { grid-template-columns: auto !important; }

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -57,6 +57,7 @@ eegosa.com##section[id*="_ads_"]
 ! ##div[id*="_AD"]
 sports.donga.com##div[id*="_AD"]
 
+chzzk.naver.com###viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"])
 a-ha.io##.fixed.h-dvh:has(> div > img[alt="coffee"])
 a-ha.io##hr:has(+ div[aria-label="advertisement"])
 a-ha.io##div[aria-label="advertisement"]

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -57,7 +57,6 @@ eegosa.com##section[id*="_ads_"]
 ! ##div[id*="_AD"]
 sports.donga.com##div[id*="_AD"]
 
-chzzk.naver.com###viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"])
 a-ha.io##.fixed.h-dvh:has(> div > img[alt="coffee"])
 a-ha.io##hr:has(+ div[aria-label="advertisement"])
 a-ha.io##div[aria-label="advertisement"]


### PR DESCRIPTION
| Before  | After |
| - | - |
<img alt="Screenshot 2026-06-21 at 6 23 37 PM" src="https://github.com/user-attachments/assets/217470e7-808d-42ed-9ffb-72f29b7552ca" /> | <img width="1986" height="1578" alt="Screenshot 2026-06-21 at 6 24 19 PM" src="https://github.com/user-attachments/assets/230faa4b-457a-4804-bff6-b6af358c079e" /> |

Both are tested with [`homeSkinCollapsedUntil` set to max](https://github.com/List-KR/List-KR/blob/4814cf2ab38371db719defe3a236a24c9a7d762a/filterslists/adblocking/filters-AG/scriptlets.txt#L22).

## Note

I narrowed the layout reset rules with specific ad href as your suggestion:

```adblock
chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header { transform: initial !important; }
chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar { transform: translateY(60px) !important; }
chzzk.naver.com#$##viewport-box + div:has(> a[href="https://chzzk.naver.com/home/sports/fifa-worldcup-2026"]) + #header + #sidebar + #layout-body { padding-top: 0 !important; }
```