### PR TITLE
advert: chzzk.naver.com swipe section ad item

### DIFF
--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -57,7 +57,7 @@ eegosa.com##section[id*="_ads_"]
 ! ##div[id*="_AD"]
 sports.donga.com##div[id*="_AD"]
 
-chzzk.naver.com###layout-body > div[class^="_container"] > div[class^="_section"] > section[class^="_container"] > div[class^="_list_"] > .flicking-viewport > .flicking-camera > div[class^="_item_"]:has(> a[href^="https://mkt.naver.com/"])
+chzzk.naver.com###layout-body > div[class^="_container_"] > div[class^="_section_"] > section[class^="_container_"] > div[class^="_list_"] > .flicking-viewport > .flicking-camera > div[class^="_item_"]:has(> a[href^="https://mkt.naver.com/"])
 a-ha.io##.fixed.h-dvh:has(> div > img[alt="coffee"])
 a-ha.io##hr:has(+ div[aria-label="advertisement"])
 a-ha.io##div[aria-label="advertisement"]

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -57,7 +57,7 @@ eegosa.com##section[id*="_ads_"]
 ! ##div[id*="_AD"]
 sports.donga.com##div[id*="_AD"]
 
-chzzk.naver.com###layout-body > div[class^="_container"] > div[class^="_section"] > section[class^="_container"] > div[class^="_list_"] > .flicking-viewport > .flicking-camera > div[class^="_item_"] > a[href^="https://mkt.naver.com/"]
+chzzk.naver.com###layout-body > div[class^="_container"] > div[class^="_section"] > section[class^="_container"] > div[class^="_list_"] > .flicking-viewport > .flicking-camera > div[class^="_item_"]:has(> a[href^="https://mkt.naver.com/"])
 a-ha.io##.fixed.h-dvh:has(> div > img[alt="coffee"])
 a-ha.io##hr:has(+ div[aria-label="advertisement"])
 a-ha.io##div[aria-label="advertisement"]

--- a/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
+++ b/filterslists/adblocking/filters-share/specific_ELEMHIDE.txt
@@ -57,6 +57,7 @@ eegosa.com##section[id*="_ads_"]
 ! ##div[id*="_AD"]
 sports.donga.com##div[id*="_AD"]
 
+chzzk.naver.com###layout-body > div[class^="_container"] > div[class^="_section"] > section[class^="_container"] > div[class^="_list_"] > .flicking-viewport > .flicking-camera > div[class^="_item_"] > a[href^="https://mkt.naver.com/"]
 a-ha.io##.fixed.h-dvh:has(> div > img[alt="coffee"])
 a-ha.io##hr:has(+ div[aria-label="advertisement"])
 a-ha.io##div[aria-label="advertisement"]


### PR DESCRIPTION
`AD`

<img width="400px" alt="Screenshot 2026-06-21 at 6 28 17 PM" src="https://github.com/user-attachments/assets/3724783d-0e08-4a5f-b349-f3870dcddc71" />

## 노트

- 규칙을 필요 이상으로 너무 상세하게 좁힌 건지 확인을 받고 싶습니다. 
- 스와이프 섹션의 항목 중에 네이버 마케팅 같이 `[AD]`라고 명시되어 있지 않아도 FC 온라인[^FC] 등 보여지는 광고가 꽤 많은데요, 차라리 해당 섹션 전체를 타겟하는 새 규칙을 추가하는 것은 어떨지 의견 남깁니다.
  <img alt="chzzk naver com_ (2)" src="https://github.com/user-attachments/assets/51e4aeb6-a665-442b-9a99-114079d8dcf7" />

[^FC]: 해당 항목의 경우 치지직 FC 온라인 스트리밍 채널 내 커뮤니티 공지로 이동합니다 - https://chzzk.naver.com/ae4d42d500bca23821e332515118a3a1/community/detail/26737449