### PR TITLE
ci: automate rotating domain updates

### DIFF
--- a/.github/workflows/rotating-domains.yml
+++ b/.github/workflows/rotating-domains.yml
@@ -1,0 +1,56 @@
+name: Update rotating domains
+
+on:
+    schedule:
+        - cron: "17 18 * * *"
+    workflow_dispatch:
+        inputs:
+            mode:
+                description: RotatingDomainsChecker run mode
+                required: true
+                default: prod_dry
+                type: choice
+                options:
+                    - prod_dry
+                    - prod_live
+                    - test_dry
+                    - test_live
+            config_path:
+                description: Path to the checker configuration
+                required: true
+                default: ./config.yml
+                type: string
+            filters_path:
+                description: Path to the filters repository
+                required: true
+                default: ./
+                type: string
+
+concurrency:
+    group: update-rotating-domains
+    cancel-in-progress: false
+
+jobs:
+    update:
+        name: Check and update domains
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        permissions:
+            contents: write
+        steps:
+            -   name: Check out repository
+                uses: actions/checkout@v7
+
+            -   name: Configure GitHub Actions author
+                run: |
+                    git config user.name "github-actions[bot]"
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+            -   name: Check rotating domains
+                uses: Alex-302/RotatingDomainsChecker@dec72766c10eb1d36ccb60a6e0593aa9bc6561d2
+                with:
+                    mode: ${{ github.event.inputs.mode || 'prod_live' }}
+                    config-path: ${{ github.event.inputs.config_path || './config.yml' }}
+                    filters-path: ${{ github.event.inputs.filters_path || './' }}
+                env:
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rotating-domains.yml
+++ b/.github/workflows/rotating-domains.yml
@@ -69,4 +69,4 @@ jobs:
             -   name: Publish updated filters
                 env:
                     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                run: gh workflow run npm.yml --ref master
+                run: gh workflow run npm.yml --ref master --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/rotating-domains.yml
+++ b/.github/workflows/rotating-domains.yml
@@ -35,6 +35,8 @@ jobs:
         name: Check and update domains
         runs-on: ubuntu-latest
         timeout-minutes: 30
+        outputs:
+            commit_sha: ${{ steps.checker.outputs['commit-sha'] }}
         permissions:
             contents: write
         steps:
@@ -47,6 +49,7 @@ jobs:
                     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
             -   name: Check rotating domains
+                id: checker
                 uses: Alex-302/RotatingDomainsChecker@dec72766c10eb1d36ccb60a6e0593aa9bc6561d2
                 with:
                     mode: ${{ github.event.inputs.mode || 'prod_live' }}
@@ -54,3 +57,16 @@ jobs:
                     filters-path: ${{ github.event.inputs.filters_path || './' }}
                 env:
                     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    publish:
+        name: Trigger publish workflow
+        needs: update
+        if: ${{ needs.update.outputs.commit_sha != '' }}
+        runs-on: ubuntu-latest
+        permissions:
+            actions: write
+        steps:
+            -   name: Publish updated filters
+                env:
+                    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                run: gh workflow run npm.yml --ref master

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,56 @@
+http:
+  timeout: 10000
+  retries: 2
+  resolveTimeout: 10000
+  heuristicTimeout: 10000
+  userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+
+processing:
+  parallel: 10
+  resolveParallel: 18
+  heuristicParallel: 20
+  redirectDepth: 20
+
+dnsPreCheck:
+  enabled: true
+  timeout: 3000
+  retryOnce: true
+
+contentProbe:
+  enabled: true
+
+antibot:
+  detectCodes: [403, 409]
+  detectUrlPattern: "__cf_chl_tk"
+
+thresholds:
+  failedDaysWarning: 14
+
+heuristic:
+  enabled: true
+  maxAttempts: 20
+  skipOnAntibot: true
+  attemptParallel: 3
+  dnsParallel: 50
+  forceHeuristicOnCodes: [403, 404, 500, 502, 503, 504]
+
+skip_text:
+  - "This domain is parked"
+  - "router.parklogic.com"
+  - "sedoParkingUrl"
+  - "We don't use this website, yet!"
+
+logging:
+  saveToFile: false
+  incremental: false
+  filePath: "logs/rotating-domains-checker.log"
+
+git:
+  mode: "prod"
+  branch: "master"
+  prBranchPrefix: "domain-rotate"
+
+filtersdir:
+  repoPath: "."
+  filterDirPattern: "filterslists"
+  filePattern: "*.txt"

--- a/watchers.yml
+++ b/watchers.yml
@@ -1,0 +1,73 @@
+sites:
+  bookto:
+    last_known_mirror: bookto05.com
+    accept_antibot: true
+    force_search_ahead: true
+  cokcok:
+    last_known_mirror: cokcok15.com
+    accept_antibot: true
+    force_search_ahead: true
+  cookmana:
+    last_known_mirror: cookmana18.com
+    accept_antibot: true
+    force_search_ahead: true
+  frtoon:
+    last_known_mirror: frtoon220.com
+    accept_antibot: true
+    force_search_ahead: true
+  hdhd:
+    last_known_mirror: hdhd344.net
+    accept_antibot: true
+    force_search_ahead: true
+  hoohootv:
+    last_known_mirror: hoohootv310.xyz
+    accept_antibot: true
+    force_search_ahead: true
+  lover:
+    last_known_mirror: lover937.net
+    accept_antibot: true
+    force_search_ahead: true
+  mato:
+    last_known_mirror: mato05.com
+    accept_antibot: true
+    force_search_ahead: true
+  newto:
+    last_known_mirror: newto05.com
+    accept_antibot: true
+    force_search_ahead: true
+  nooo:
+    last_known_mirror: nooo10.tv
+    accept_antibot: true
+    force_search_ahead: true
+  opworlds:
+    last_known_mirror: opworlds18.com
+    accept_antibot: true
+    force_search_ahead: true
+  sbxh:
+    last_known_mirror: sbxh1.com
+    accept_antibot: true
+    force_search_ahead: true
+  torrentbot:
+    last_known_mirror: torrentbot200.site
+    accept_antibot: true
+    force_search_ahead: true
+  torrentpi:
+    last_known_mirror: torrentpi150.com
+    accept_antibot: true
+    force_search_ahead: true
+  torrentqq:
+    last_known_mirror: torrentqq390.com
+    accept_antibot: true
+    force_search_ahead: true
+  wfwf:
+    last_known_mirror: wfwf449.com
+    accept_antibot: true
+    force_search_ahead: true
+  yako:
+    last_known_mirror: yako01.com
+    accept_antibot: true
+    force_search_ahead: true
+  yasyadong:
+    last_known_mirror: yasyadong01.tv
+    accept_antibot: true
+    force_search_ahead: true


### PR DESCRIPTION
## Summary
- add a daily RotatingDomainsChecker workflow with direct github-actions[bot] commits
- expose prod_live, prod_dry, test_live, test_dry, config path, and filters path through workflow_dispatch
- track the 18 rotating-domain families currently represented by concrete filter-domain lists

## Validation
- pnpm test
- pnpm lint
- RotatingDomainsChecker v1.5.1 prod_dry (18 watchers, 178 filter files)
- workflow_dispatch input assertion and YAML parse