### PR TITLE
incorrect blocking: chzzk.naver.com adult content

### DIFF
--- a/filterslists/adblocking/filters-AG/antiadblock.txt
+++ b/filterslists/adblocking/filters-AG/antiadblock.txt
@@ -245,9 +245,7 @@ chzzk.naver.com#%#//scriptlet('trusted-json-set', 'JSON.parse', 'meta.p2p', 'fal
 chzzk.naver.com#%#//scriptlet('json-prune', 'media.[].p2pPath media.[].p2pPathUrlEncoding media.[].encodingTrack.[].p2pPath media.[].encodingTrack.[].p2pPathUrlEncoding')
 chzzk.naver.com#%#//scriptlet('trusted-suppress-native-method', 'atob', '"c2V0UmVxdWVzdEhlYWRlcg=="', 'abort')
 chzzk.naver.com#%#//scriptlet('trusted-suppress-native-method', 'atob', '"Y3J5cHRv"', 'abort')
-chzzk.naver.com#%#//scriptlet('json-prune-xhr-response', 'content.dab', '', 'live-detail')
 chzzk.naver.com#%#//scriptlet('json-prune-xhr-response', 'content.dab', '', '/videos/')
-chzzk.naver.com#%#//scriptlet('json-prune-fetch-response', 'content.dab', '', 'live-detail')
 chzzk.naver.com#%#//scriptlet('json-prune-fetch-response', 'content.dab', '', '/videos/')
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_cli || adguard_app_android)
 ||nam.veta.naver.com/vas|$xmlhttprequest,domain=chzzk.naver.com,redirect=nooptext

--- a/filterslists/adblocking/filters-AG/antiadblock.txt
+++ b/filterslists/adblocking/filters-AG/antiadblock.txt
@@ -245,8 +245,6 @@ chzzk.naver.com#%#//scriptlet('trusted-json-set', 'JSON.parse', 'meta.p2p', 'fal
 chzzk.naver.com#%#//scriptlet('json-prune', 'media.[].p2pPath media.[].p2pPathUrlEncoding media.[].encodingTrack.[].p2pPath media.[].encodingTrack.[].p2pPathUrlEncoding')
 chzzk.naver.com#%#//scriptlet('trusted-suppress-native-method', 'atob', '"c2V0UmVxdWVzdEhlYWRlcg=="', 'abort')
 chzzk.naver.com#%#//scriptlet('trusted-suppress-native-method', 'atob', '"Y3J5cHRv"', 'abort')
-chzzk.naver.com#%#//scriptlet('json-prune-xhr-response', 'content.dab', '', '/videos/')
-chzzk.naver.com#%#//scriptlet('json-prune-fetch-response', 'content.dab', '', '/videos/')
 !#if (adguard_app_windows || adguard_app_mac || adguard_app_cli || adguard_app_android)
 ||nam.veta.naver.com/vas|$xmlhttprequest,domain=chzzk.naver.com,redirect=nooptext
 ||nam.veta.naver.com/gfp$xmlhttprequest,domain=chzzk.naver.com,redirect=nooptext

--- a/filterslists/adblocking/filters-uBO/antiadblock.txt
+++ b/filterslists/adblocking/filters-uBO/antiadblock.txt
@@ -124,10 +124,6 @@ chzzk.naver.com##+js(trusted-json-edit, .meta.p2p=false)
 chzzk.naver.com##+js(json-prune, media.[].p2pPath media.[].p2pPathUrlEncoding media.[].encodingTrack.[].p2pPath media.[].encodingTrack.[].p2pPathUrlEncoding)
 chzzk.naver.com##+js(trusted-suppress-native-method, atob, c2V0UmVxdWVzdEhlYWRlcg==, abort)
 chzzk.naver.com##+js(trusted-suppress-native-method, atob, Y3J5cHRv, abort)
-chzzk.naver.com##+js(json-prune-xhr-response, content.dab, , propsToMatch, url:/live-detail)
-chzzk.naver.com##+js(json-prune-xhr-response, content.dab, , propsToMatch, url:/videos/)
-chzzk.naver.com##+js(json-prune-fetch-response, content.dab, , propsToMatch, url:/live-detail)
-chzzk.naver.com##+js(json-prune-fetch-response, content.dab, , propsToMatch, url:/videos/)
 ||nam.veta.naver.com/vas$xhr,domain=chzzk.naver.com,redirect=noop.txt
 ||nam.veta.naver.com/gfp$xhr,domain=chzzk.naver.com,redirect=noop.txt
 ||nam.veta.naver.com/call$xhr,domain=chzzk.naver.com,redirect=noop.txt


### PR DESCRIPTION
## Problem

With List-KR enabled, age-verified users can be treated as unauthenticated on 19+ CHZZK content:

- Adult live channels show the verification gate.
- Adult VOD thumbnails remain hidden behind the age-restriction placeholder.
- Adult VOD pages can ask an already signed-in user to log in and verify again.

Disabling AdGuard protection restores the adult-content state.

## Fix

Remove the XHR/fetch response-pruning scriptlets that delete content.dab from live-detail and videos responses. Remove the equivalent rules from both the AdGuard and uBO filter variants.

The remaining playback JSON rules continue to handle the P2P fields without pruning the outer API responses.

## Verification

- Disabled only the two live-detail rules in AdGuard: an adult live player loaded and playback progressed (readyState=4).
- Reloaded a non-adult live channel with the same configuration: playback also progressed (readyState=4).
- Disabled only the two videos rules in AdGuard: adult VOD thumbnails were restored.
- pnpm lint
- pnpm test
- pnpm build